### PR TITLE
feat(types): add `filter-input` to HTMLElementTagNameMap

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -167,6 +167,9 @@ declare global {
   interface Window {
     FilterInputElement: typeof FilterInputElement
   }
+  interface HTMLElementTagNameMap {
+    'filter-input': FilterInputElement
+  }
 }
 
 if (!window.customElements.get('filter-input')) {


### PR DESCRIPTION
This PR adds `filter-input` to the global `HTMLElementTagNameMap` interface.

This is essentially the type-level equivalent of adding the tag to the global registry. 

Since it is now a globally-recognized element, it's treated as a first class citizen in
the DOM, receiving full type support when using `<filter-input>` directly in your code,
or adding event listeners, and so on.